### PR TITLE
Updating Calling applicant page. 

### DIFF
--- a/teams/ambassadors/applicant-outreach/calling-applicants.md
+++ b/teams/ambassadors/applicant-outreach/calling-applicants.md
@@ -27,11 +27,12 @@ If the person doesn't remember they have applied:
 Person remebers they have applied:
 * Ask them how they are finding the course
 * Ensure they know of the various ways they can stay in touch with us and get help:
-  * Slack
+  * Joining the Intro to Coding Slack
   * Leaving a comment on their application
   * Attending a weekend workshop 
-  You may wish to leave these links in a comment on their application or ask a volunteer with access to CYF email account to forward on these links on. 
-  
+* You may wish to leave these links in a comment on their application or ask a volunteer with access to CYF email account to forward on these links on. 
+* Tip: Have a template email with all these links ready for your city.
+ 
 * Let the applicant know about the opportunity to apply for the 8-month Full Stack course 
 * Remind applicants of any upcoming deadlines to apply for the Full Stack Web development course and explain the applicantion process. 
 

--- a/teams/ambassadors/applicant-outreach/calling-applicants.md
+++ b/teams/ambassadors/applicant-outreach/calling-applicants.md
@@ -16,15 +16,15 @@ Many applicants suffer from isolation and depression, so a call at this stage ca
 Go to the dashbaord to find an applicant to call. If you do not have access to the dashboard or applicant's phone numbers please contact your city co-ordinator
 Ensure you hide your number by using either 141 or #31# (depending on your network)
 
-The phone call. 
+### The phone call. 
 * Its always best to start with who you are 'Hello I'm x calling from Code your Future 
 
-If the person doesn't remember they have applied:
+### If the person doesn't remember they have applied:
 * The person may not remember they have applied. If so give them a quick reminder that they applied for the Code Your Future Intro to Coding Course.
 * Ask them to go to course1.codeyourfuture.io to check out what we do and if they’d like to continue with the process
 * Many access via entering their email. They will receive a link to the applicant dashboard when they enter their email so tell them to look for this
 
-Person remebers they have applied:
+### Person remembers they have applied:
 * Ask them how they are finding the course
 * Ensure they know of the various ways they can stay in touch with us and get help:
   * Joining the Intro to Coding Slack
@@ -36,7 +36,7 @@ Person remebers they have applied:
 * Let the applicant know about the opportunity to apply for the 8-month Full Stack course 
 * Remind applicants of any upcoming deadlines to apply for the Full Stack Web development course and explain the applicantion process. 
 
-If the person has completed all steps:
+### If the person has completed all steps:
 * Congratulate them! 
 * If they would like to join the Full stack course they must have also attended at least one Intro to Coding Workshop
 * Let them know that they will recieve an invitation to an interview to join our full stack course. 
@@ -47,7 +47,7 @@ Once you have called an applicant, record this call on the dashboard and move on
 
 **Material for calling applicants**
 
-* Call scripts will be send to you
+* More detailed Call scripts and voice recordings of example calls can be sent to you
 * [F.A.Q](https://codeyourfuture.io/faq/). - especially useful when calling NGOs and Applicants
 * [Intro to Coding course steps and process to apply for the Full Stack course](https://docs.codeyourfuture.io/course-processes/before-the-course/application-process#9-interview-scheduling-and-invites)
 * Training will be provided

--- a/teams/ambassadors/applicant-outreach/calling-applicants.md
+++ b/teams/ambassadors/applicant-outreach/calling-applicants.md
@@ -14,7 +14,7 @@ Many applicants suffer from isolation and depression, so a call at this stage ca
 ## Step by Step guide to making an applicant call.
 
 Go to the dashbaord to find an applicant to call. If you do not have access to the dashboard or applicant's phone numbers please contact your city co-ordinator
-Ensure you hide your number by using either 141 or #31# (depending on your network)
+Ensure you hide your number by using either 141 or #31# (depends and may differ on your network and region)
 
 ### The phone call. 
 * Its always best to start with who you are 'Hello I'm x calling from Code your Future 
@@ -23,6 +23,7 @@ Ensure you hide your number by using either 141 or #31# (depending on your netwo
 * The person may not remember they have applied. If so give them a quick reminder that they applied for the Code Your Future Intro to Coding Course.
 * Ask them to go to course1.codeyourfuture.io to check out what we do and if they’d like to continue with the process
 * Many access via entering their email. They will receive a link to the applicant dashboard when they enter their email so tell them to look for this
+* Follow up with an email containing useful link to course1.codeyourfuture.io and CYF website
 
 ### Person remembers they have applied:
 * Ask them how they are finding the course
@@ -31,10 +32,9 @@ Ensure you hide your number by using either 141 or #31# (depending on your netwo
   * Leaving a comment on their application
   * Attending a weekend workshop 
 * You may wish to leave these links in a comment on their application or ask a volunteer with access to CYF email account to forward on these links on. 
-* Tip: Have a template email with all these links ready for your city.
- 
+*Tip: Have a template email with all these links ready for your city!*
 * Let the applicant know about the opportunity to apply for the 8-month Full Stack course 
-* Remind applicants of any upcoming deadlines to apply for the Full Stack Web development course and explain the applicantion process. 
+* Remind applicants of any upcoming deadlines to apply for the Full Stack Web development course and explain the application process. 
 
 ### If the person has completed all steps:
 * Congratulate them! 

--- a/teams/ambassadors/applicant-outreach/calling-applicants.md
+++ b/teams/ambassadors/applicant-outreach/calling-applicants.md
@@ -10,12 +10,45 @@ While the applicants are working on the tutorials, it is important at this time 
 
 Many applicants suffer from isolation and depression, so a call at this stage can provide a lot of motivation to students.
 
+
+## Step by Step guide to making an applicant call.
+
+Go to the dashbaord to find an applicant to call. If you do not have access to the dashboard or applicant's phone numbers please contact your city co-ordinator
+Ensure you hide your number by using either 141 or #31# (depending on your network)
+
+The phone call. 
+* Its always best to start with who you are 'Hello I'm x calling from Code your Future 
+
+If the person doesn't remember they have applied:
+* The person may not remember they have applied. If so give them a quick reminder that they applied for the Code Your Future Intro to Coding Course.
+* Ask them to go to course1.codeyourfuture.io to check out what we do and if they’d like to continue with the process
+* Many access via entering their email. They will receive a link to the applicant dashboard when they enter their email so tell them to look for this
+
+Person remebers they have applied:
+* Ask them how they are finding the course
+* Ensure they know of the various ways they can stay in touch with us and get help:
+  * Slack
+  * Leaving a comment on their application
+  * Attending a weekend workshop 
+  You may wish to leave these links in a comment on their application or ask a volunteer with access to CYF email account to forward on these links on. 
+  
+* Let the applicant know about the opportunity to apply for the 8-month Full Stack course 
+* Remind applicants of any upcoming deadlines to apply for the Full Stack Web development course and explain the applicantion process. 
+
+If the person has completed all steps:
+* Congratulate them! 
+* If they would like to join the Full stack course they must have also attended at least one Intro to Coding Workshop
+* Let them know that they will recieve an invitation to an interview to join our full stack course. 
+* More information on the interview can be found [here](https://docs.codeyourfuture.io/course-processes/before-the-course/application-process#9-interview-scheduling-and-invites) 
+
+
 Once you have called an applicant, record this call on the dashboard and move onto the next one.
 
 **Material for calling applicants**
 
 * Call scripts will be send to you
 * [F.A.Q](https://codeyourfuture.io/faq/). - especially useful when calling NGOs and Applicants
+* [Intro to Coding course steps and process to apply for the Full Stack course](https://docs.codeyourfuture.io/course-processes/before-the-course/application-process#9-interview-scheduling-and-invites)
 * Training will be provided
 
 ## Facebook Groups


### PR DESCRIPTION
Added in some more detail to the calling applicant page- will hopefully mean that the calling applicant script google doc will not be needed.

I thought adding this information here would make it quicker and easier for volunteers to find the information and links they need. The links to other parts of the docs website should also make the experience smoother for volunteers. 